### PR TITLE
feat(JOML): migrate remaining occurrences

### DIFF
--- a/src/main/java/org/terasology/kcomputers/TerasologyEntityContext.java
+++ b/src/main/java/org/terasology/kcomputers/TerasologyEntityContext.java
@@ -17,8 +17,6 @@ package org.terasology.kcomputers;
 
 import org.terasology.kallisti.base.component.ComponentContext;
 import org.terasology.kallisti.base.interfaces.ConnectedContext;
-import org.terasology.math.geom.Vector3i;
-import org.terasology.world.BlockEntityRegistry;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/terasology/kcomputers/components/KallistiConnectableComponent.java
+++ b/src/main/java/org/terasology/kcomputers/components/KallistiConnectableComponent.java
@@ -16,7 +16,6 @@
 package org.terasology.kcomputers.components;
 
 import org.terasology.entitySystem.Component;
-import org.terasology.kallisti.base.component.Machine;
 
 /**
  * Component provided by blocks which connect to Kallisti component neighbors.

--- a/src/main/java/org/terasology/kcomputers/components/KallistiDisplayCandidateComponent.java
+++ b/src/main/java/org/terasology/kcomputers/components/KallistiDisplayCandidateComponent.java
@@ -16,12 +16,10 @@
 package org.terasology.kcomputers.components;
 
 import org.terasology.entitySystem.Component;
-import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.kallisti.base.interfaces.Synchronizable;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collection;
 
 /**
  * Component provided by blocks which

--- a/src/main/java/org/terasology/kcomputers/components/KallistiDisplayComponent.java
+++ b/src/main/java/org/terasology/kcomputers/components/KallistiDisplayComponent.java
@@ -16,6 +16,7 @@
 package org.terasology.kcomputers.components;
 
 import com.google.common.primitives.UnsignedBytes;
+import org.joml.Vector3f;
 import org.joml.Vector3i;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.management.AssetManager;
@@ -31,8 +32,8 @@ import org.terasology.kcomputers.KComputersUtil;
 import org.terasology.kcomputers.assets.HexFont;
 import org.terasology.math.JomlUtil;
 import org.terasology.math.Side;
-import org.joml.Vector3f;
 import org.terasology.network.NoReplicate;
+import org.terasology.nui.Color;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.material.MaterialData;
@@ -40,7 +41,6 @@ import org.terasology.rendering.assets.mesh.MeshBuilder;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.assets.texture.TextureData;
 import org.terasology.rendering.logic.MeshComponent;
-import org.terasology.nui.Color;
 import org.terasology.utilities.Assets;
 import org.terasology.world.block.BlockComponent;
 import org.terasology.world.block.BlockPart;
@@ -198,7 +198,7 @@ public class KallistiDisplayComponent implements Component, FrameBuffer, Synchro
             component.hideFromOwner = false;
             component.color = Color.WHITE;
 
-            mesh.add(entityManager, DISPLAY_KEY, JomlUtil.from(new Vector3f(location)), component);
+            mesh.add(entityManager, DISPLAY_KEY, new Vector3f(location), component);
         }
 
         self.saveComponent(mesh);

--- a/src/main/java/org/terasology/kcomputers/components/MeshRenderComponent.java
+++ b/src/main/java/org/terasology/kcomputers/components/MeshRenderComponent.java
@@ -15,12 +15,12 @@
  */
 package org.terasology.kcomputers.components;
 
+import org.joml.Vector3f;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.location.LocationComponent;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.rendering.logic.MeshComponent;
 
 import java.util.HashMap;

--- a/src/main/java/org/terasology/kcomputers/components/parts/KallistiMachineOpenComputersComponent.java
+++ b/src/main/java/org/terasology/kcomputers/components/parts/KallistiMachineOpenComputersComponent.java
@@ -26,9 +26,9 @@ import org.terasology.jnlua.LuaState53;
 import org.terasology.kallisti.base.component.ComponentContext;
 import org.terasology.kallisti.base.component.Machine;
 import org.terasology.kallisti.oc.MachineOpenComputers;
-import org.terasology.kcomputers.components.KallistiMachineProvider;
 import org.terasology.kcomputers.assets.HexFont;
 import org.terasology.kcomputers.assets.KallistiArchive;
+import org.terasology.kcomputers.components.KallistiMachineProvider;
 import org.terasology.registry.CoreRegistry;
 
 /**

--- a/src/main/java/org/terasology/kcomputers/components/parts/KallistiOpenComputersGPUComponent.java
+++ b/src/main/java/org/terasology/kcomputers/components/parts/KallistiOpenComputersGPUComponent.java
@@ -15,16 +15,8 @@
  */
 package org.terasology.kcomputers.components.parts;
 
-import com.google.common.collect.ImmutableSet;
 import org.terasology.entitySystem.Component;
-import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.kallisti.base.component.ComponentInterface;
-import org.terasology.kallisti.base.component.ComponentRule;
-import org.terasology.kallisti.oc.MachineOpenComputers;
-import org.terasology.kallisti.oc.OCGPURenderer;
-import org.terasology.kallisti.oc.PeripheralOCGPU;
-
-import java.util.Collection;
 
 /**
  * Component providing an OpenComputers-style GPU peripheral.

--- a/src/main/java/org/terasology/kcomputers/events/KallistiAttachComponentsEvent.java
+++ b/src/main/java/org/terasology/kcomputers/events/KallistiAttachComponentsEvent.java
@@ -18,15 +18,11 @@ package org.terasology.kcomputers.events;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
 import org.terasology.kallisti.base.component.ComponentContext;
-import org.terasology.kallisti.base.component.Machine;
 import org.terasology.kcomputers.TerasologyEntityContext;
-import org.terasology.network.ServerEvent;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 

--- a/src/main/java/org/terasology/kcomputers/events/KallistiGatherConnectedEntitiesEvent.java
+++ b/src/main/java/org/terasology/kcomputers/events/KallistiGatherConnectedEntitiesEvent.java
@@ -17,16 +17,10 @@ package org.terasology.kcomputers.events;
 
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
-import org.terasology.kallisti.base.component.ComponentContext;
-import org.terasology.kcomputers.TerasologyEntityContext;
-import org.terasology.network.ServerEvent;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
-import java.util.Map;
 import java.util.Set;
 
 /**

--- a/src/main/java/org/terasology/kcomputers/peripherals/PeripheralTransposer.java
+++ b/src/main/java/org/terasology/kcomputers/peripherals/PeripheralTransposer.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.kcomputers.peripherals;
 
+import org.joml.Vector3i;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.kallisti.base.component.ComponentMethod;
 import org.terasology.kallisti.base.component.Peripheral;
@@ -22,7 +23,6 @@ import org.terasology.logic.inventory.InventoryComponent;
 import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.logic.inventory.ItemComponent;
 import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.BlockComponent;
@@ -141,8 +141,9 @@ public class PeripheralTransposer implements Peripheral {
     @Nullable
     protected Vector3i getNeighborPos(int side) {
         Side sideT = PeripheralUtils.sideOCToTerasology(side);
+        Vector3i tmp = new Vector3i();
 
-        return sideT != null ? sideT.getAdjacentPos(block.getPosition()) : null;
+        return sideT != null ? sideT.getAdjacentPos(block.getPosition(tmp), tmp) : null;
     }
 
     @Override

--- a/src/main/java/org/terasology/kcomputers/systems/KallistiComponentConnectionSystem.java
+++ b/src/main/java/org/terasology/kcomputers/systems/KallistiComponentConnectionSystem.java
@@ -17,6 +17,7 @@ package org.terasology.kcomputers.systems;
 
 import gnu.trove.set.TLongSet;
 import gnu.trove.set.hash.TLongHashSet;
+import org.joml.Vector3i;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeDeactivateComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
@@ -31,7 +32,6 @@ import org.terasology.kcomputers.TerasologyEntityContext;
 import org.terasology.kcomputers.components.KallistiComputerComponent;
 import org.terasology.kcomputers.events.KallistiGatherConnectedEntitiesEvent;
 import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
 import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.WorldProvider;
@@ -110,10 +110,10 @@ public class KallistiComponentConnectionSystem extends BaseComponentSystem {
     @ReceiveEvent
     public void componentDeactivated(BeforeDeactivateComponent event, EntityRef entity, BlockComponent component) {
         removeNoLongerVisibleComponents(entity);
-
+        Vector3i pos = new Vector3i();
         for (Side side : Side.values()) {
-            Vector3i pos = side.getAdjacentPos(component.getPosition());
-            if (pos != null && provider.isBlockRelevant(pos) && blockEntityRegistry.hasPermanentBlockEntity(pos)) {
+            side.getAdjacentPos(component.getPosition(pos), pos);
+            if (provider.isBlockRelevant(pos) && blockEntityRegistry.hasPermanentBlockEntity(pos)) {
                 EntityRef ref = blockEntityRegistry.getBlockEntityAt(pos);
                 if (ref != null && ref.exists()) {
                     removeNoLongerVisibleComponents(ref);

--- a/src/main/java/org/terasology/kcomputers/systems/KallistiComputerSystem.java
+++ b/src/main/java/org/terasology/kcomputers/systems/KallistiComputerSystem.java
@@ -35,9 +35,9 @@ import org.terasology.kcomputers.components.KallistiConnectableComponent;
 import org.terasology.kcomputers.components.KallistiInventoryWithContainerComponent;
 import org.terasology.kcomputers.components.KallistiMachineProvider;
 import org.terasology.kcomputers.components.parts.KallistiMemoryComponent;
+import org.terasology.kcomputers.events.KallistiChangeComputerStateEvent;
 import org.terasology.kcomputers.events.KallistiGatherConnectedEntitiesEvent;
 import org.terasology.kcomputers.events.KallistiRegisterComponentRulesEvent;
-import org.terasology.kcomputers.events.KallistiChangeComputerStateEvent;
 import org.terasology.logic.chat.ChatMessageEvent;
 import org.terasology.logic.inventory.InventoryComponent;
 import org.terasology.math.Side;
@@ -48,7 +48,12 @@ import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.BlockComponent;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * This system handles computer initialization, as well as - currently - entity

--- a/src/main/java/org/terasology/kcomputers/systems/KallistiComputerSystem.java
+++ b/src/main/java/org/terasology/kcomputers/systems/KallistiComputerSystem.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.kcomputers.systems;
 
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeDeactivateComponent;
 import org.terasology.entitySystem.event.ReceiveEvent;
@@ -41,7 +43,6 @@ import org.terasology.kcomputers.events.KallistiRegisterComponentRulesEvent;
 import org.terasology.logic.chat.ChatMessageEvent;
 import org.terasology.logic.inventory.InventoryComponent;
 import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
 import org.terasology.world.BlockEntityRegistry;
@@ -131,10 +132,10 @@ public class KallistiComputerSystem extends BaseComponentSystem implements Updat
 
     @ReceiveEvent
     public void addConnectedEntitiesConnectable(KallistiGatherConnectedEntitiesEvent event, EntityRef ref, BlockComponent blockComponent, KallistiConnectableComponent connectableComponent) {
-        Vector3i pos = blockComponent.getPosition();
-
+        Vector3ic pos = blockComponent.getPosition(new Vector3i());
+        Vector3i location = new Vector3i();
         for (Side side : Side.values()) {
-            Vector3i location = new Vector3i(pos).add(side.getVector3i());
+            pos.add(side.direction(), location);
             if (provider.isBlockRelevant(location) && blockEntityRegistry.hasPermanentBlockEntity(location)) {
                 event.addEntity(blockEntityRegistry.getBlockEntityAt(location));
             }
@@ -200,7 +201,7 @@ public class KallistiComputerSystem extends BaseComponentSystem implements Updat
         MultiValueMap<Vector3i, TerasologyEntityContext> contextsPerPos = new CollectionBackedMultiValueMap<>(new HashMap<>(), ArrayList::new);
 
         TerasologyEntityContext contextComputer = new TerasologyEntityContext(ref.getId(), -1);
-        contextsPerPos.add(ref.getComponent(BlockComponent.class).getPosition(), contextComputer);
+        contextsPerPos.add(ref.getComponent(BlockComponent.class).getPosition(new Vector3i()), contextComputer);
 
         for (EntityRef lref : gatherEvent.getEntities()) {
             kallistiComponents.putAll(KComputersUtil.gatherKallistiComponents(lref));
@@ -217,7 +218,7 @@ public class KallistiComputerSystem extends BaseComponentSystem implements Updat
             }
             // add neighbors
             for (Side side : Side.values()) {
-                Vector3i vecSided = new Vector3i(vec).add(side.getVector3i());
+                Vector3i vecSided = new Vector3i(vec).add(side.direction());
                 for (TerasologyEntityContext to : contextsPerPos.values(vecSided)) {
                     for (TerasologyEntityContext from : contextsPerPos.values(vec)) {
                         // It will add both ways, as we will be iterating through the parameters

--- a/src/main/java/org/terasology/kcomputers/systems/KallistiPeripheralSystem.java
+++ b/src/main/java/org/terasology/kcomputers/systems/KallistiPeripheralSystem.java
@@ -26,6 +26,7 @@ import org.terasology.kallisti.base.component.ComponentRule;
 import org.terasology.kallisti.oc.MachineOpenComputers;
 import org.terasology.kallisti.oc.OCGPURenderer;
 import org.terasology.kallisti.oc.PeripheralOCGPU;
+import org.terasology.kcomputers.assets.KallistiArchive;
 import org.terasology.kcomputers.components.machines.KallistiTransposerComponent;
 import org.terasology.kcomputers.components.parts.KallistiEEPROMAssetedComponent;
 import org.terasology.kcomputers.components.parts.KallistiFilesystemAssetedComponent;
@@ -35,7 +36,6 @@ import org.terasology.kcomputers.components.parts.KallistiOpenComputersGPUCompon
 import org.terasology.kcomputers.events.KallistiAttachComponentsEvent;
 import org.terasology.kcomputers.events.KallistiRegisterComponentRulesEvent;
 import org.terasology.kcomputers.peripherals.ByteArrayStaticByteStorage;
-import org.terasology.kcomputers.assets.KallistiArchive;
 import org.terasology.kcomputers.peripherals.PeripheralTransposer;
 import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.logic.inventory.ItemComponent;


### PR DESCRIPTION
- feat(JOML): migrate MeshRenderComponent
- chore: optimize imports
- feat(JOML): migrate PeripheralTransposer
- feat(JOML): migrate KallistiComputerSystem
- feat(JOML): migrate KallistiComponentConnectionSystem

This removes the last occurrences of `org.terasology.math.geom` from this module :partying_face:

Contributes to MovingBlocks/Terasology#3832
