### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/kcomputers/components/KallistiComputerComponent.java
+++ b/src/main/java/org/terasology/kcomputers/components/KallistiComputerComponent.java
@@ -11,8 +11,8 @@ import org.terasology.kallisti.base.component.Machine;
  * instance.
  */
 public class KallistiComputerComponent implements Component<KallistiComputerComponent> {
-    private boolean on;
-    private transient Machine machine;
+    public boolean on;
+    public transient Machine machine;
 
     /**
      * Get the Kallisti virtual machine instance held in this component.

--- a/src/main/java/org/terasology/kcomputers/components/KallistiDisplayCandidateComponent.java
+++ b/src/main/java/org/terasology/kcomputers/components/KallistiDisplayCandidateComponent.java
@@ -40,7 +40,7 @@ public class KallistiDisplayCandidateComponent implements Component<KallistiDisp
      */
     public boolean multiBlock = false;
 
-    private transient KallistiDisplayComponent display;
+    public transient KallistiDisplayComponent display;
 
     /**
      * Get the KallistiDisplayComponent instance.

--- a/src/main/java/org/terasology/kcomputers/components/KallistiDisplayComponent.java
+++ b/src/main/java/org/terasology/kcomputers/components/KallistiDisplayComponent.java
@@ -50,7 +50,7 @@ import java.nio.ByteBuffer;
  */
 @NoReplicate
 public class KallistiDisplayComponent implements Component<KallistiDisplayComponent>, FrameBuffer, Synchronizable.Receiver {
-    private static final String DISPLAY_KEY = "display";
+    public static final String DISPLAY_KEY = "display";
 
     private transient EntityManager entityManager;
     private transient EntityRef self;

--- a/src/main/java/org/terasology/kcomputers/components/MeshRenderComponent.java
+++ b/src/main/java/org/terasology/kcomputers/components/MeshRenderComponent.java
@@ -26,7 +26,7 @@ import java.util.Map;
  * using the provided methods.
  */
 public class MeshRenderComponent implements Component<MeshRenderComponent> {
-    private final Map<String, EntityRef> meshes = new HashMap<>();
+    public final Map<String, EntityRef> meshes = new HashMap<>();
 
     /**
      * Dispose of a given mesh entity and its sub-elements.


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191